### PR TITLE
hotfix: table subtitle width 수정

### DIFF
--- a/src/components/InformationBox/Table/index.tsx
+++ b/src/components/InformationBox/Table/index.tsx
@@ -68,7 +68,7 @@ const Container = styled.div`
 `;
 
 const SubTitle = styled.h3`
-    width: 160px;
+    width: auto;
     height: 45px;
     padding: 10px 0;
     padding-bottom: 0;


### PR DESCRIPTION
- 고정 너비 때문에 문구가 깨지는 현상 발생