### PR TITLE
fix: 컴포넌트 마운트 시 initial fetch 비활성화

### DIFF
--- a/src/components/Map/MapContainer.tsx
+++ b/src/components/Map/MapContainer.tsx
@@ -59,9 +59,11 @@ const MapContainer = ({
     const targetRef = useRef<HTMLDivElement>(null);
     const nav = useNavigate();
     const [searchQuery, setSearchQuery] = useState<string>("");
-    const { data, status, fetchNextPage, hasNextPage } =
+    const { data, status, fetchNextPage, hasNextPage, refetch } =
         useSLInfQuery(searchQuery);
-    const [observe, unobserve] = useObserver(fetchNextPage);
+    const [observe, unobserve] = useObserver(() => {
+        fetchNextPage();
+    });
 
     const [info, setInfo] = useState<IStore>({
         _id: 0,
@@ -73,6 +75,10 @@ const MapContainer = ({
     const [ovPlaceList, setOvPlaceList] = useState<IStores>([]);
     const [isVisible, setIsVisible] = useState<boolean>(false);
     const [HLMarker, setHLMarker] = useState<IStore | null>(null);
+
+    useEffect(() => {
+        refetch({ refetchPage: (page, index) => index === 1 });
+    }, [searchQuery]);
 
     useEffect(() => {
         setOvPlaceList([]);

--- a/src/hooks/queries/useStoreList.ts
+++ b/src/hooks/queries/useStoreList.ts
@@ -18,14 +18,14 @@ export const useStoreList = (
         ["ywc.storeList", q, page],
         async () => {
             const request = await getStoreList(q, String(page), size, city);
-            return request.data;
+            return request?.data;
         },
         { enabled: false },
     );
 };
 
 export const useSLInfQuery = (q: string) => {
-    const { data, status, isFetching, fetchNextPage, hasNextPage } =
+    const { data, status, fetchNextPage, hasNextPage, refetch } =
         useInfiniteQuery<{
             result: responseType;
             nextPage: number;
@@ -34,12 +34,13 @@ export const useSLInfQuery = (q: string) => {
         }>(
             ["ywc.storeList.infQuery", q],
             async ({ pageParam = 1 }) => {
-                const request: AxiosResponse<responseType> = await getStoreList(
+                const request = await getStoreList(
                     q,
                     String(pageParam),
                     10,
                     null,
                 );
+
                 return {
                     currentPage: pageParam,
                     result: request.data,
@@ -53,8 +54,9 @@ export const useSLInfQuery = (q: string) => {
                         ? undefined
                         : lastPage.nextPage;
                 },
+                enabled: false,
             },
         );
 
-    return { data, status, isFetching, fetchNextPage, hasNextPage };
+    return { data, status, fetchNextPage, hasNextPage, refetch };
 };

--- a/src/hooks/useObserver.ts
+++ b/src/hooks/useObserver.ts
@@ -2,7 +2,7 @@ import { useRef } from "react";
 
 const useObserver = (callback: () => void) => {
     const observer = useRef(
-        new IntersectionObserver((entries, observer) => {
+        new IntersectionObserver((entries) => {
             entries.forEach((entry) => {
                 entry.isIntersecting && callback();
             });


### PR DESCRIPTION
- 컴포넌트 마운트 시 공문자열 query로 fetching하는 불필요한 request 발생
- enabled: false 옵션 통해 initial fetch 비활성화
- searchQuery가 바뀔 때마다 refetch 진행